### PR TITLE
pin setuptools to v69.5.1 in model_requirements.txt

### DIFF
--- a/llm/utils/model_requirements.txt
+++ b/llm/utils/model_requirements.txt
@@ -5,3 +5,4 @@ accelerate==0.22.0
 einops==0.6.1
 bitsandbytes==0.41.1
 scipy==1.11.4
+setuptools==69.5.1


### PR DESCRIPTION
The current version (v0.2 and v0.2.1) of nai-llm-k8s fails to run inference with a ModuleNotFoundError.

From pod logs when starting inference:
```
2024-06-11T04:43:55,927 [INFO ] W-9000-tinyllama_fe8a4ea1ffedaf415f4da2f062534de366a451e6-stdout MODEL_LOG - ModuleNotFoundError: No module named 'ts.torch_handler.handler'
```
@pipoe2h figured out that if we pin setuptools to the previous version (69.5.1) in model_requirements.txt and then generate the MAR, this issue is not seen.